### PR TITLE
search for input relative to the active window

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,9 +36,9 @@ Search for "Open Policy Agent" in the Extensions (Shift ⌘ X) panel and then in
 
 ## Tips
 
-### Set the `input` document by creating `input.json` at the root of your workspace.
+### Set the `input` document by creating `input.json`
 
-The extension will look for a file called `input.json` in the root of the workspace to specify for the `input` document when you evaluate policies. If you modify this file and re-run evaluation you will see the affect of the changes.
+The extension will look for a file called `input.json` in the current directory of the policy file being evaluated, or at the root of the workspace, and will use it as the `input` document when evaluating policies. If you modify this file and re-run evaluation you will see the affect of the changes.
 
 ### Bind keyboard shortcuts for frequently used commands.
 


### PR DESCRIPTION
Thanks for making this extension! I am using it when the workspace dir is containing multiple sub directories which contains policies. Usually when evaluating a policy in a directory I need to test it with an input that works for it so I have some input examples in the root and I need to manually rename input.json back and forth. With this PR we can have a local input.json (in the same dir as the policy) that will override the root input.json if it exists (if not then it's same as before).

This intent is also captured in this issue: https://github.com/open-policy-agent/vscode-opa/issues/27.

related: https://github.com/open-policy-agent/vscode-opa/issues/28
