### PR TITLE
support fileDirname variable in roots configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Search for "Open Policy Agent" in the Extensions (Shift ⌘ X) panel and then in
 | --- | --- | --- |
 | `opa.path` | `null` | Set path of OPA executable. |
 | `opa.checkOnSave` | `false` | Enable automatic checking of .rego files on save. |
-| `opa.roots` | `[${workspaceFolder}]` | List of paths to load as bundles for policy and data. Defaults to a single entry which is the current workspace root. The variable `${workspaceFolder}` will be resolved as the current workspace root. |
+| `opa.roots` | `[${workspaceFolder}]` | List of paths to load as bundles for policy and data. Defaults to a single entry which is the current workspace root. The variable `${workspaceFolder}` will be resolved as the current workspace root. The variable `${fileDirname} will be resolved as the directory of the file currently opened in the active window. |
 | `opa.bundleMode`  | `true`  | Enable treating the workspace as a bundle to avoid loading erroneous data JSON/YAML files. It is _NOT_ recommended to disable this. |
 
 > For bundle documentation refer to [https://www.openpolicyagent.org/docs/latest/management/#bundle-file-format](https://www.openpolicyagent.org/docs/latest/management/#bundle-file-format).

--- a/src/opa.ts
+++ b/src/opa.ts
@@ -7,6 +7,7 @@ import * as vscode from 'vscode';
 import { promptForInstall } from './install-opa';
 import { getImports, getPackage } from './util';
 import { existsSync } from 'fs';
+import { dirname } from 'path';
 
 var regoVarPattern = new RegExp('^[a-zA-Z_][a-zA-Z0-9_]*$');
 
@@ -43,6 +44,7 @@ export function getRoots(): string[] {
     let formattedRoots = new Array();
     roots.forEach(root => {
         root = root.replace('${workspaceFolder}', vscode.workspace.workspaceFolders![0].uri.toString());
+        root = root.replace('${fileDirname}', dirname(vscode.window.activeTextEditor!.document.fileName));
         formattedRoots.push(getDataDir(vscode.Uri.parse(root)));
     });
 


### PR DESCRIPTION
`opa.roots` already supports the conventional `${workspaceFolder}` built-in variable. This PR adds another conventional and useful variable: `${fileDirname}` which is resolved with the directory of the file opened in the active window. This was also mentioned in https://github.com/open-policy-agent/vscode-opa/issues/27 where a user intuitively tried to use this but the extension didn't support it then.

for reference: https://code.visualstudio.com/docs/editor/variables-reference