### PR TITLE
Bumping version to 0.10.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,10 +4,10 @@
 	"displayName": "Open Policy Agent",
 	"repository": {
 		"type": "git",
-		"url": "https://github.com/tsandall/vscode-opa.git"
+		"url": "https://github.com/open-policy-agent/vscode-opa.git"
 	},
 	"description": "Develop, test, debug, and analyze policies for the Open Policy Agent project.",
-	"version": "0.8.0",
+	"version": "0.10.0",
 	"publisher": "tsandall",
 	"engines": {
 		"vscode": "^1.21.0"


### PR DESCRIPTION
and updating repository link to point to repo owned by open-policy-agent.

Signed-off-by: Johan Fylling <johan.dev@fylling.se>