### PR TITLE
Adding support for compiler strict-mode for OPA check command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Change Log
 
-All notable changes to the vscode-opa extension will be documented in this file.
+## 0.11.0
+
+- Adding support for compiler strict-mode (`--strict`) for OPA `check` command
 
 ## 0.10.0
 

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Search for "Open Policy Agent" in the Extensions (Shift ⌘ X) panel and then in
 | --- | --- | --- |
 | `opa.path` | `null` | Set path of OPA executable. |
 | `opa.checkOnSave` | `false` | Enable automatic checking of .rego files on save. |
+| `opa.strictMode` | `false` | Enable [strict-mode](https://www.openpolicyagent.org/docs/latest/strict/) for the `OPA: Check File Syntax command`. |
 | `opa.roots` | `[${workspaceFolder}]` | List of paths to load as bundles for policy and data. Defaults to a single entry which is the current workspace root. The variable `${workspaceFolder}` will be resolved as the current workspace root. The variable `${fileDirname}` will be resolved as the directory of the file currently opened in the active window. |
 | `opa.bundleMode`  | `true`  | Enable treating the workspace as a bundle to avoid loading erroneous data JSON/YAML files. It is _NOT_ recommended to disable this. |
 | `opa.schema` | `null` | Path to the [schema](https://www.openpolicyagent.org/docs/latest/schemas/) file or directory. If set to `null`, schema evaluation is disabled. As for `opa.roots`, `${workspaceFolder}` and `${fileDirname}` variables can be used in the path. |

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
 						"boolean"
 					],
 					"default": false,
-					"description": "Run opa check on save. Defaults to false"
+					"description": "Run OPA check on save. Defaults to false"
 				},
 				"opa.roots": {
 					"type": [
@@ -100,6 +100,13 @@
 					],
 					"default": null,
 					"description": "Path to the schema file or directory. Defaults to null. If null, schema evaluation is disabled."
+				},
+				"opa.strictMode": {
+					"type": [
+						"boolean"
+					],
+					"default": false,
+					"description": "Enable strict-mode for the OPA: Check File Syntax command (OPA check)"
 				}
 			}
 		},

--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
 						"boolean"
 					],
 					"default": false,
-					"description": "Enable strict-mode for the OPA: Check File Syntax command (OPA check)"
+					"description": "Enable strict-mode for the \"OPA: Check File Syntax\" command (OPA check)"
 				}
 			}
 		},

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -242,7 +242,10 @@ function activateCheckFile(context: vscode.ExtensionContext) {
 
         // Only check rego files
         if (doc.languageId === 'rego') {
-            let args: string[] = ['check'];
+            let args: string[] = ['check']; 
+            if (opa.canUseStrictFlag()) {
+                args.push('--strict');
+            }
             if (opa.canUseBundleFlags()) {
                 args.push('--bundle');
             }

--- a/src/opa.ts
+++ b/src/opa.ts
@@ -30,7 +30,7 @@ export function canUseBundleFlags(): boolean {
 
 export function canUseStrictFlag(): boolean {
     let strictMode = vscode.workspace.getConfiguration('opa').get<boolean>('strictMode', true);
-    return strictMode && installedOPASameOrNewerThan("0.37.0-dev");
+    return strictMode && installedOPASameOrNewerThan("0.37.0");
 }
 
 function dataFlag(): string {
@@ -143,7 +143,7 @@ function parseOPAVersion(s: string): any[] {
 
 // returns the installed OPA version as a string.
 function getOPAVersionString(): string {
-    let opaPath = getOpaPath('opa', false);
+    const opaPath = getOpaPath('opa', false);
     if (opaPath === undefined) {
         return '';
     }

--- a/src/opa.ts
+++ b/src/opa.ts
@@ -28,6 +28,11 @@ export function canUseBundleFlags(): boolean {
     return installedOPASameOrNewerThan("0.14.0-dev") && bundleMode;
 }
 
+export function canUseStrictFlag(): boolean {
+    let strictMode = vscode.workspace.getConfiguration('opa').get<boolean>('strictMode', true);
+    return strictMode && installedOPASameOrNewerThan("0.37.0-dev");
+}
+
 function dataFlag(): string {
     if (canUseBundleFlags()) {
         return "--bundle";
@@ -138,8 +143,12 @@ function parseOPAVersion(s: string): any[] {
 
 // returns the installed OPA version as a string.
 function getOPAVersionString(): string {
+    let opaPath = getOpaPath('opa', false);
+    if (opaPath === undefined) {
+        return '';
+    }
 
-    const result = cp.spawnSync('opa', ['version']);
+    const result = cp.spawnSync(opaPath, ['version']);
     if (result.status !== 0) {
         return '';
     }
@@ -200,9 +209,7 @@ export function run(path: string, args: string[], stdin: string, onSuccess: (std
     });
 }
 
-// runWithStatus executes the OPA binary at path with args and stdin. The
-// callback is invoked with the exit status, stderr, and stdout buffers.
-export function runWithStatus(path: string, args: string[], stdin: string, cb: (code: number, stderr: string, stdout: string) => void) {
+function getOpaPath(path: string, shouldPromptForInstall: boolean): string | undefined {
     let opaPath = vscode.workspace.getConfiguration('opa').get<string>('path');
     if (opaPath !== undefined && opaPath !== null) {
         opaPath = opaPath.replace('${workspaceFolder}', vscode.workspace.workspaceFolders![0].uri.fsPath.toString());
@@ -212,18 +219,31 @@ export function runWithStatus(path: string, args: string[], stdin: string, cb: (
     const existsInUserSettings = opaPath !== undefined && opaPath !== null && existsSync(opaPath);
 
     if (!(existsOnPath || existsInUserSettings)) {
-        promptForInstall();
-        return;
+        if (shouldPromptForInstall) {
+            promptForInstall();
+        }
+        return undefined;
     }
 
     if (existsInUserSettings && opaPath !== undefined) {
         // Prefer OPA in User Settings to the one installed on $PATH
-        path = opaPath;
+        return opaPath;
     }
 
-    console.log("spawn:", path, "args:", args.toString());
+    return path;
+}
 
-    let proc = cp.spawn(path, args);
+// runWithStatus executes the OPA binary at path with args and stdin. The
+// callback is invoked with the exit status, stderr, and stdout buffers.
+export function runWithStatus(path: string, args: string[], stdin: string, cb: (code: number, stderr: string, stdout: string) => void) {
+    let opaPath = getOpaPath(path, true);
+    if (opaPath === undefined) {
+        return;
+    }
+
+    console.log("spawn:", opaPath, "args:", args.toString());
+
+    let proc = cp.spawn(opaPath, args);
 
     proc.stdin.write(stdin);
     proc.stdin.end();


### PR DESCRIPTION
Can be toggled through opa.strictMode configuration flag.

Fixing: #63
Signed-off-by: Johan Fylling <johan.dev@fylling.se>