### PR TITLE
Add activationEvents back since

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
 			"devDependencies": {
 				"@types/mocha": "10.0.6",
 				"@types/node": "20.11.13",
-				"@types/vscode": "1.85.0",
+				"@types/vscode": "1.75.0",
 				"@typescript-eslint/eslint-plugin": "^6.14.0",
 				"@typescript-eslint/parser": "^6.14.0",
 				"eslint": "^8.56.0",
@@ -259,9 +259,9 @@
 			"dev": true
 		},
 		"node_modules/@types/vscode": {
-			"version": "1.85.0",
-			"resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.85.0.tgz",
-			"integrity": "sha512-CF/RBon/GXwdfmnjZj0WTUMZN5H6YITOfBCP4iEZlOtVQXuzw6t7Le7+cR+7JzdMrnlm7Mfp49Oj2TuSXIWo3g==",
+			"version": "1.75.0",
+			"resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.75.0.tgz",
+			"integrity": "sha512-SAr0PoOhJS6FUq5LjNr8C/StBKALZwDVm3+U4pjF/3iYkt3GioJOPV/oB1Sf1l7lROe4TgrMyL5N1yaEgTWycw==",
 			"dev": true
 		},
 		"node_modules/@typescript-eslint/eslint-plugin": {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,9 @@
 	"engines": {
 		"vscode": "^1.75.0"
 	},
+	"activationEvents": [
+		"onLanguage:rego"
+	],
 	"categories": [
 		"Programming Languages"
 	],
@@ -164,7 +167,7 @@
 	"devDependencies": {
 		"@types/mocha": "10.0.6",
 		"@types/node": "20.11.13",
-		"@types/vscode": "1.85.0",
+		"@types/vscode": "1.75.0",
 		"@typescript-eslint/eslint-plugin": "^6.14.0",
 		"@typescript-eslint/parser": "^6.14.0",
 		"eslint": "^8.56.0",


### PR DESCRIPTION
Previously this had been removed due to this: 

<img width="586" alt="Screenshot 2024-02-22 at 13 46 54" src="https://github.com/open-policy-agent/vscode-opa/assets/1774239/47ba7679-9a48-4ebb-a094-0b77562f2e1a">


These changes surfaced when runing vsce publish