### PR TITLE
Add configuration to set environment variables for opa subprocess

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Search for "Open Policy Agent" in the Extensions (Shift ⌘ X) panel and then in
 | `opa.schema` | `null` | Path to the [schema](https://www.openpolicyagent.org/docs/latest/schemas/) file or directory. If set to `null`, schema evaluation is disabled. As for `opa.roots`, `${workspaceFolder}` and `${fileDirname}` variables can be used in the path. |
 | `editor.formatOnSave` | `false` | Enable reformatting the current document on save by using `opa fmt`. |
 | `opa.languageServers` | `null` | An array of enabled language servers (currently `["regal"]` is supported) |
+| `opa.env` | `{}` | Object of environment variables passed to the process running OPA (e.g. `{"key": "value"}`) |
 
 > For bundle documentation refer to [https://www.openpolicyagent.org/docs/latest/management/#bundle-file-format](https://www.openpolicyagent.org/docs/latest/management/#bundle-file-format).
   Note that data files *MUST* be named either `data.json` or `data.yaml`.

--- a/package.json
+++ b/package.json
@@ -135,6 +135,14 @@
 					],
 					"default": null,
 					"description": "Enable the specified Rego and OPA related language servers. Supports: ['regal'], Default: []."
+				},
+				"opa.env": {
+				  "type": "object",
+				  "additionalProperties": {
+				    "type": "string"
+				  },
+				  "default": {},
+				  "description": "Environment variables passed to the process running OPA."
 				}
 			}
 		},

--- a/src/opa.ts
+++ b/src/opa.ts
@@ -300,6 +300,10 @@ function getOpaPath(context: vscode.ExtensionContext | undefined, path: string, 
     }
 }
 
+function getOpaEnv(): NodeJS.ProcessEnv {
+    return vscode.workspace.getConfiguration('opa').get<NodeJS.ProcessEnv>('env', {});
+}
+
 // runWithStatus executes the OPA binary at path with args and stdin. The
 // callback is invoked with the exit status, stderr, and stdout buffers.
 export function runWithStatus(context: vscode.ExtensionContext | undefined, path: string, args: string[], stdin: string, cb: (code: number, stderr: string, stdout: string) => void) {
@@ -310,7 +314,7 @@ export function runWithStatus(context: vscode.ExtensionContext | undefined, path
 
     console.log("spawn:", opaPath, "args:", args.toString());
 
-    let proc = cp.spawn(opaPath, args);
+    let proc = cp.spawn(opaPath, args, {env: getOpaEnv()});
 
     proc.stdin.write(stdin);
     proc.stdin.end();


### PR DESCRIPTION
This PR adds a new setting (`opa.env`) that allows you to set environment variables that will then be passed to the process that is running OPA.

![opa-vscode-env](https://github.com/open-policy-agent/vscode-opa/assets/63304184/88fbaced-f7f2-4bcb-a736-29920670f95d)

---

resolves #50