### PR TITLE
Use .jsonc extension for output.json

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -112,7 +112,7 @@ export function activate(context: vscode.ExtensionContext) {
     });
 }
 
-const outputUri = vscode.Uri.parse(`json:output.json`);
+const outputUri = vscode.Uri.parse(`json:output.jsonc`);
 
 let coveredHighlight = vscode.window.createTextEditorDecorationType({
     backgroundColor: 'rgba(64,128,64,0.5)',


### PR DESCRIPTION
This PR changes the file extension of the output file from `json` to `jsonc` to prevent VS Code from marking the comment as an error.

---

resolves #97 