### PR TITLE
Address issue in Regal LS startups

### DIFF
--- a/src/ls/activate.ts
+++ b/src/ls/activate.ts
@@ -4,7 +4,6 @@ import * as vscode from 'vscode';
 
 import {
     activateRegal,
-    activatedRegal,
     deactivateRegal,
 } from './clients/regal';
 import { supportedLanguageServers } from './ls';
@@ -22,9 +21,7 @@ export function activateLanguageServers(context: vscode.ExtensionContext) {
 
         switch (languageServerID) {
             case 'regal':
-                if (activatedRegal()) {
-                    deactivateRegal();
-                }
+                deactivateRegal();
                 break;
         }
     }
@@ -33,9 +30,7 @@ export function activateLanguageServers(context: vscode.ExtensionContext) {
     for (const languageServer of configuredLanguageServers) {
         switch (languageServer) {
             case 'regal':
-                if (!activatedRegal()) {
-                    activateRegal(context);
-                }
+                activateRegal(context);
                 break;
         }
     }


### PR DESCRIPTION
When VS code starts, there is an issue where the configuration is 'changed' multiple times during start-up. This happened too quickly for the activatedRegal function to reliably test if regal was running already and caused many servers to be started.

This meant that sometimes messages would be duplicated since many servers would send the same message.

The minimum regal version has also been bumped, to contain fixes for non-workspaced vs code instances. (see https://github.com/StyraInc/regal/pull/580)