### PR TITLE
docs: correct eval.gif link

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 * Toggle Coverage of Selections
 * Start and show messages from the [Regal](https://docs.styra.com/regal) Language server
 
-![Use of the extension to lint and eval Rego code](https://raw.githubusercontent.com/tsandall/vscode-opa/master/eval.gif)
+![Use of the extension to lint and eval Rego code](https://raw.githubusercontent.com/open-policy-agent/vscode-opa/master/eval.gif)
 
 ## Requirements
 


### PR DESCRIPTION
I think this must have been a full link for display at https://marketplace.visualstudio.com/items?itemName=tsandall.opa - so I have left it like that.