### PR TITLE
Allow `${workspaceFolder}` to be used in env var values

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,21 @@ Search for "Open Policy Agent" in the Extensions (Shift ⌘ X) panel and then in
 | `opa.languageServers` | `null` | An array of enabled language servers (currently `["regal"]` is supported) |
 | `opa.env` | `{}` | Object of environment variables passed to the process running OPA (e.g. `{"key": "value"}`) |
 
+Note that the `${workspaceFolder}` variable will expand to a full URI of the workspace, as expected by most VS Code commands. The `${workspacePath}` variable may additionally be used where only the path component (i.e. without the `file://` schema component) of the workspace URI is required.
+
+### Using `opa.env` to set OPA command line flags
+
+From OPA v0.62.0 and onwards, it's possible to set any command line flag via environment variables as an alternative to arguments to the various `opa` commands. This allows using the `opa.env` object for setting any flag to the commmands executed by the extension. The format of the environment variables follows the pattern `OPA_<COMMAND>_<FLAG>` where `COMMAND` is the command name in uppercase (like `EVAL`) and `FLAG` is the flag name in uppercase (like `IGNORE`). For example, to set the `--capabilities` flag for the `opa check` and `opa eval` command, use the following configuration in your `.vscode/settings.json` file:
+
+```json
+{
+    "opa.env": {
+        "OPA_CHECK_CAPABILITIES": "${workspacePath}/misc/capabilities.json",
+        "OPA_EVAL_CAPABILITIES": "${workspacePath}/misc/capabilities.json"
+    }
+}
+```
+
 > For bundle documentation refer to [https://www.openpolicyagent.org/docs/latest/management/#bundle-file-format](https://www.openpolicyagent.org/docs/latest/management/#bundle-file-format).
   Note that data files *MUST* be named either `data.json` or `data.yaml`.
 
@@ -76,6 +91,10 @@ Bind the `OPA: Evaluate Package` command to a keyboard shortcut (e.g., ⌘ Shift
 If unable to use `data.json` or `data.yaml` files with `opa.bundleMode` enabled
 you can disable the configuration option and *ALL* `*.json` and `*.yaml` files
 will be loaded from the workspace.
+
+## Debugging OPA command evaluation
+
+In case some command isn't behaving as you expect, you can see exactly what command was executed by opening the developer tools from the **Help** menu and check the **Console** tab.
 
 ## Development
 

--- a/src/opa.ts
+++ b/src/opa.ts
@@ -301,7 +301,9 @@ function getOpaPath(context: vscode.ExtensionContext | undefined, path: string, 
 }
 
 function getOpaEnv(): NodeJS.ProcessEnv {
-    return vscode.workspace.getConfiguration('opa').get<NodeJS.ProcessEnv>('env', {});
+    let env = vscode.workspace.getConfiguration('opa').get<NodeJS.ProcessEnv>('env', {});
+
+    return Object.fromEntries(Object.entries(env).map(([k, v]) => [k, replacePathVariables(v as string)]));
 }
 
 // runWithStatus executes the OPA binary at path with args and stdin. The

--- a/src/util.ts
+++ b/src/util.ts
@@ -52,6 +52,7 @@ export function getPrettyTime(ns: number): string {
 export function replaceWorkspaceFolderPathVariable(path: string): string {
     if (vscode.workspace.workspaceFolders !== undefined) {
         path = path.replace('${workspaceFolder}', vscode.workspace.workspaceFolders![0].uri.toString());
+        path = path.replace('${workspacePath}', vscode.workspace.workspaceFolders![0].uri.path);
     } else if (path.indexOf('${workspaceFolder}') >= 0) {
         vscode.window.showWarningMessage('${workspaceFolder} variable configured in settings, but no workspace is active');
     }


### PR DESCRIPTION
Additionally, add a `${workspacePath}` for commands that don't accept a full URI including the `file://` schema.