### PR TITLE
Fix edge case in `opa.test.workspace` activation

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -432,11 +432,6 @@ function activateEvalCoverage(context: vscode.ExtensionContext) {
 }
 
 function activateTestWorkspace(context: vscode.ExtensionContext) {
-    const editor = vscode.window.activeTextEditor;
-    if (!editor) {
-        return;
-    }
-
     const testWorkspaceCommand = vscode.commands.registerCommand('opa.test.workspace', () => {
         opaOutputChannel.show(true);
         opaOutputChannel.clear();
@@ -451,6 +446,10 @@ function activateTestWorkspace(context: vscode.ExtensionContext) {
             }
             args.push(...opa.getRoots());
         }, () => {
+            const editor = vscode.window.activeTextEditor;
+            if (!editor) {
+                return;
+            }
             args.push(editor.document.uri.fsPath);
         });
 


### PR DESCRIPTION
Defer `vscode.window.activeTextEditor` check in `opa.test.workspace` command activation, as there might still be a workspace loaded.

Might still break on editing a single file, but I think that behavior is rather undefined given the name of the command explicitly states it's for testing a workspace.

Fixes #115