### PR TITLE
Update vscode engine

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "typescript-eslint": "^7.5.0"
       },
       "engines": {
-        "vscode": "^1.75.0"
+        "vscode": "^1.87.0"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "version": "0.13.4",
   "publisher": "tsandall",
   "engines": {
-    "vscode": "^1.75.0"
+    "vscode": "^1.87.0"
   },
   "activationEvents": [
     "onLanguage:rego"


### PR DESCRIPTION
This is required with the version of types that we have upgraded to. This version is (1.87.0) quite recent, Feb 2024.

I think our other option is to downgrade the @types/vscode package.

This is blocking our next release: https://github.com/open-policy-agent/vscode-opa/actions/runs/8552690488/job/23434325929