### PR TITLE
regal: when restarting regal, reuse output channel

### DIFF
--- a/src/ls/clients/regal.ts
+++ b/src/ls/clients/regal.ts
@@ -20,6 +20,7 @@ import { execSync } from 'child_process';
 
 let client: LanguageClient;
 let clientLock = false;
+let outChan: vscode.OutputChannel;
 
 const minimumSupportedRegalVersion = '0.18.0';
 
@@ -121,6 +122,10 @@ class debuggableMessageStrategy {
 }
 
 export function activateRegal(_context: ExtensionContext) {
+    if (!outChan) {
+        outChan = window.createOutputChannel("Regal");
+    }
+
     // activateRegal is run when the config changes, but this happens a few times
     // at startup. We use clientLock to prevent the activation of multiple instances.
     if (clientLock) {
@@ -149,8 +154,6 @@ export function activateRegal(_context: ExtensionContext) {
         command: regalPath(),
         args: ["language-server"],
     };
-
-    const outChan = window.createOutputChannel("Regal");
 
     const clientOptions: LanguageClientOptions = {
         documentSelector: [{ scheme: 'file', language: 'rego' }],


### PR DESCRIPTION
This addresses an issue where the output channel would be recreated many times as Regal was restarted.

before 

https://github.com/open-policy-agent/vscode-opa/assets/1774239/a872e2ce-dbad-444f-b7af-de056ca36015



after

https://github.com/open-policy-agent/vscode-opa/assets/1774239/8eef8652-7162-4668-889a-b737edda9bca

