### PR TITLE
Support syntax highlighting in markdown code blocks

### DIFF
--- a/package.json
+++ b/package.json
@@ -174,6 +174,16 @@
         "language": "rego",
         "scopeName": "source.rego",
         "path": "./syntaxes/Rego.tmLanguage"
+      },
+      {
+        "scopeName": "markdown.rego.codeblock",
+        "path": "./syntaxes/markdown-inject.json",
+        "injectTo": [
+          "text.html.markdown"
+        ],
+        "embeddedLanguages": {
+          "meta.embedded.block.rego": "rego"
+        }
       }
     ]
   },

--- a/syntaxes/markdown-inject.json
+++ b/syntaxes/markdown-inject.json
@@ -1,0 +1,45 @@
+{
+	"fileTypes": [],
+	"injectionSelector": "L:text.html.markdown",
+	"patterns": [
+		{
+			"include": "#rego-code-block"
+		}
+	],
+	"repository": {
+		"rego-code-block": {
+			"begin": "(^|\\G)(\\s*)(\\`{3,}|~{3,})\\s*(?i:(rego)(\\s+[^`~]*)?$)",
+			"name": "markup.fenced_code.block.markdown",
+			"end": "(^|\\G)(\\2|\\s{0,3})(\\3)\\s*$",
+			"beginCaptures": {
+				"3": {
+					"name": "punctuation.definition.markdown"
+				},
+				"4": {
+					"name": "fenced_code.block.language.markdown"
+				},
+				"5": {
+					"name": "fenced_code.block.language.attributes.markdown"
+				}
+			},
+			"endCaptures": {
+				"3": {
+					"name": "punctuation.definition.markdown"
+				}
+			},
+			"patterns": [
+				{
+					"begin": "(^|\\G)(\\s*)(.*)",
+					"while": "(^|\\G)(?!\\s*([`~]{3,})\\s*$)",
+					"contentName": "meta.embedded.block.rego",
+					"patterns": [
+						{
+							"include": "source.rego"
+						}
+					]
+				}
+			]
+		}
+	},
+	"scopeName": "markdown.rego.codeblock"
+}


### PR DESCRIPTION
Based on the example provided in https://github.com/mjbvz/vscode-fenced-code-block-grammar-injection-example

Fixes #176

<img width="723" alt="Screenshot 2024-05-21 at 12 18 09" src="https://github.com/open-policy-agent/vscode-opa/assets/510711/4c55bce6-0937-408f-a327-37b22804cf29">
