### PR TITLE
Check for OS architecture when installing OPA CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ In case some command isn't behaving as you expect, you can see exactly what comm
 
 ## Development
 
-If you want to hack on the extension itself, you should clone this repository, install the dependencies (`npm install`) and use Visual Studio Code's Debugger (F5) to test your changes.
+If you want to hack on the extension itself, you should clone this repository, install the dependencies (`npm install --include=dev`) and use Visual Studio Code's Debugger (F5) to test your changes.
 
 ## ROADMAP
 


### PR DESCRIPTION
When installing the extension in VS Code and proceeding with the prompt to install the OPA CLI binary, I noticed that the `amd64` version was installed on my `arm64` macbook:

<img width="1226" alt="Screenshot 2024-07-10 at 10 31 35 PM" src="https://github.com/open-policy-agent/vscode-opa/assets/6244502/c164924f-2a49-4bf5-a3c5-a8ef7740c1b6">

This PR fixes that and ensures that the binary selected from the assets matches the platform architecture of the machine.

<img width="1342" alt="Screenshot 2024-07-10 at 10 27 04 PM" src="https://github.com/open-policy-agent/vscode-opa/assets/6244502/2994c0c4-9d36-4be4-9cfb-67cdf22a15b8">
