### PR TITLE
Show eval string values in quotes

### DIFF
--- a/src/ls/clients/regal.ts
+++ b/src/ls/clients/regal.ts
@@ -298,7 +298,7 @@ function handleRegalShowEvalResult(params: any) {
         }
 
         if (typeof params.result.value == 'string') {
-            attachmentMessage = String(params.result.value).replace(/ /g, '\u00a0')
+            attachmentMessage = `"` + String(params.result.value).replace(/ /g, '\u00a0') + `"`
             // for strings, which may be long, there is a preference for wrapping
             // over horizontal scroll present in a pre block.
             hoverMessage = hoverTitle + "`" + attachmentMessage + "`";


### PR DESCRIPTION
This makes the distinction with undefined clearer.


https://github.com/user-attachments/assets/7301aa9c-1583-49d8-a70f-8cfb25be45cd

