### PR TITLE
feat: add config property to set trace level

### DIFF
--- a/package.json
+++ b/package.json
@@ -160,6 +160,17 @@
           ],
           "default": "opa-fmt",
           "description": "The formatter to use for Rego. Supports: ['opa-fmt', 'opa-fmt-rego-v1', 'regal-fix']."
+        },
+        "regal.trace.server": {
+          "scope": "window",
+          "type": "string",
+          "enum": [
+            "off",
+            "messages",
+            "verbose"
+          ],
+          "default": "off",
+          "description": "Traces the communication between VS Code and the Regal language server."
         }
       }
     },


### PR DESCRIPTION
This PR adds the ability to set the trace level for intercepting requests and responses between client and server.

```bash
[Trace - 01:54:39] Sending request 'initialize - (0)'.
Params: {
    "processId": 91401,
    "clientInfo": {
        "name": "Visual Studio Code",
        "version": "1.92.1"
    },
    "locale": "en",
    "rootPath": "/Users/.../projects/rego-lsp-test",
    "rootUri": "file:///Users/.../projects/rego-lsp-test",
    "capabilities": {
        "workspace": {
            "applyEdit": true,
            "workspaceEdit": {
                "documentChanges": true,
                "resourceOperations": [
                    "create",
                    "rename",
                    "delete"
                ],
...
```