### PR TITLE
Add startDebugging handler

### DIFF
--- a/src/ls/clients/regal.ts
+++ b/src/ls/clients/regal.ts
@@ -210,6 +210,7 @@ export function activateRegal(_context: ExtensionContext) {
   );
 
   client.onRequest<void, ShowEvalResultParams>("regal/showEvalResult", handleRegalShowEvalResult);
+  client.onRequest<void, vscode.DebugConfiguration>("regal/startDebugging", handleDebug);
 
   client.start();
 }
@@ -281,6 +282,15 @@ interface EvalResult {
   value: any;
   isUndefined: boolean;
   printOutput: { [line: number]: [text: string[]] };
+}
+
+function handleDebug(params: vscode.DebugConfiguration) {
+  const activeEditor = vscode.window.activeTextEditor;
+  if (!activeEditor) {
+    return;
+  }
+
+  vscode.debug.startDebugging(undefined, params);
 }
 
 function handleRegalShowEvalResult(params: ShowEvalResultParams) {


### PR DESCRIPTION
This may be called from an LSP server to have a debugging session started with the launch configuration in the payload.