### PR TITLE
grammar: Address < xml escaping issue

### DIFF
--- a/syntaxes/Rego.tmLanguage
+++ b/syntaxes/Rego.tmLanguage
@@ -206,7 +206,7 @@
 		<key>interpolation-expression</key>
 		<dict>
 			<key>begin</key>
-			<string>(?<!\\)\{</string>
+			<string>(?&lt;!\\)\{</string>
 			<key>beginCaptures</key>
 			<dict>
 				<key>0</key>


### PR DESCRIPTION
This seems to work in the ext, but not in linguist without this update.