### PR TITLE
Show 'Evaluating...' in eval output while running

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -344,6 +344,8 @@ function activateEvalPackage(context: vscode.ExtensionContext) {
         const { inputPath, args } = createOpaEvalArgs(editor, pkg);
         args.push("--metrics");
 
+        provider.set(outputUri, "// Evaluating...", undefined);
+
         opa.run("opa", args, "data." + pkg, (stderr, result) => {
           setEvalOutput(provider, outputUri, stderr, result, inputPath, "data." + pkg);
         }, opaOutputShowError);
@@ -368,6 +370,8 @@ function activateEvalSelection(context: vscode.ExtensionContext) {
         args.push("--metrics");
 
         const text = editor.document.getText(editor.selection);
+
+        provider.set(outputUri, "// Evaluating...", undefined);
 
         opa.run("opa", args, text, (stderr, result) => {
           setEvalOutput(provider, outputUri, stderr, result, inputPath, text);
@@ -403,6 +407,8 @@ function activateEvalCoverage(context: vscode.ExtensionContext) {
         args.push("--coverage");
 
         const text = editor.document.getText(editor.selection);
+
+        provider.set(outputUri, "// Evaluating...", undefined);
 
         opa.run("opa", args, text, (stderr, result) => {
           setEvalOutput(provider, outputUri, stderr, result, inputPath, text);


### PR DESCRIPTION
This makes it clear a new run has been started.

Fixes https://github.com/open-policy-agent/vscode-opa/issues/20


https://github.com/user-attachments/assets/710d5779-f7af-44e2-aedb-4bd5987aac8d

