### PR TITLE
Disable color decorators for Rego files

### DIFF
--- a/package.json
+++ b/package.json
@@ -288,7 +288,12 @@
           }
         }
       }
-    ]
+    ],
+    "configurationDefaults": {
+      "[rego]": {
+        "editor.defaultColorDecorators": false
+      }
+    }
   },
   "scripts": {
     "vscode:prepublish": "npm run compile",


### PR DESCRIPTION
Configure editor to turn off color highlighting in Rego code files. This prevents unwanted color decorations in Rego syntax.

Fixes https://github.com/open-policy-agent/vscode-opa/issues/382

after
<img width="151" height="92" alt="Screenshot 2026-01-22 at 11 06 43" src="https://github.com/user-attachments/assets/b7727c3d-6b58-45c0-a5c5-a9bc9de51fb9" />
before
<img width="125" height="86" alt="Screenshot 2026-01-22 at 11 06 27" src="https://github.com/user-attachments/assets/0d82aa80-b537-4903-b9e7-d174145add40" />
