### PR TITLE
Add syntax highlighting in Rego metadata comments

### DIFF
--- a/syntaxes/Rego.tmLanguage
+++ b/syntaxes/Rego.tmLanguage
@@ -50,18 +50,61 @@
 		</dict>
 		<key>comment</key>
 		<dict>
-			<key>captures</key>
-			<dict>
-				<key>1</key>
+			<key>patterns</key>
+			<array>
 				<dict>
+					<key>match</key>
+					<string>(#)\s*(METADATA)\s*$\n?</string>
+					<key>captures</key>
+					<dict>
+						<key>1</key>
+						<dict>
+							<key>name</key>
+							<string>punctuation.definition.comment.rego</string>
+						</dict>
+						<key>2</key>
+						<dict>
+							<key>name</key>
+							<string>strong</string>
+						</dict>
+					</dict>
 					<key>name</key>
-					<string>punctuation.definition.comment.rego</string>
+					<string>comment.line.number-sign.rego</string>
 				</dict>
-			</dict>
-			<key>match</key>
-			<string>(#).*$\n?</string>
-			<key>name</key>
-			<string>comment.line.number-sign.rego</string>
+				<dict>
+					<key>match</key>
+					<string>(#)\s*(scope|title|description|related_resources|authors|organizations|schemas|entrypoint|custom):.*$\n?</string>
+					<key>captures</key>
+					<dict>
+						<key>1</key>
+						<dict>
+							<key>name</key>
+							<string>punctuation.definition.comment.rego</string>
+						</dict>
+						<key>2</key>
+						<dict>
+							<key>name</key>
+							<string>strong</string>
+						</dict>
+					</dict>
+					<key>name</key>
+					<string>comment.line.number-sign.rego</string>
+				</dict>
+				<dict>
+					<key>captures</key>
+					<dict>
+						<key>1</key>
+						<dict>
+							<key>name</key>
+							<string>punctuation.definition.comment.rego</string>
+						</dict>
+					</dict>
+					<key>match</key>
+					<string>(#).*$\n?</string>
+					<key>name</key>
+					<string>comment.line.number-sign.rego</string>
+				</dict>
+			</array>
 		</dict>
 		<key>constant</key>
 		<dict>


### PR DESCRIPTION
Update comment pattern matching to recognize some metadata annotation keys.

Related to https://github.com/open-policy-agent/vscode-opa/issues/200 (mostly)