### PR TITLE
regal: Implement server side testing

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -157,7 +157,7 @@ export async function activate(context: vscode.ExtensionContext) {
       activateExplorerCommand(context, opaTreeDataProvider);
     }
 
-    if (capabilities.serverTestingProvider) {
+    if (capabilities.opaTestProvider) {
       activateTestController(context);
       setTestController({ handleTestLocations });
     }

--- a/src/ls/clients/regal.ts
+++ b/src/ls/clients/regal.ts
@@ -28,7 +28,7 @@ export interface RegalServerCustomCapabilities {
   explorerProvider: boolean;
   inlineEvalProvider: boolean;
   debugProvider: boolean;
-  serverTestingProvider: boolean;
+  opaTestProvider: boolean;
 }
 
 // RegalClientActivationOptions is intended to be represent how the client
@@ -56,7 +56,7 @@ function extractServerCustomCapabilities(
     explorerProvider: experimental?.explorerProvider ?? false,
     inlineEvalProvider: experimental?.inlineEvalProvider ?? false,
     debugProvider: experimental?.debugProvider ?? false,
-    serverTestingProvider: experimental?.serverTestingProvider ?? false,
+    opaTestProvider: experimental?.opaTestProvider ?? false,
   };
 }
 
@@ -65,13 +65,14 @@ let clientLock = false;
 let regalShowDiagnostics = true;
 const activeDebugSessions: Map<string, void> = new Map();
 let treeDataProvider: OPATreeDataProvider | undefined;
-let testController: { handleTestLocations: (uri: string, locations: TestLocation[]) => void } | undefined;
+let testController:
+  | { handleTestLocations: (uri: string, locations: TestLocation[]) => void }
+  | undefined;
 
 // Test location from Regal's regal/testLocations notification
 export interface TestLocation {
-  kind: "single_test" | "file_test" | "package_test";
   package: string;
-  test: string;
+  name: string;
   location: {
     col: number;
     row: number;
@@ -79,6 +80,24 @@ export interface TestLocation {
     file: string;
     text: string;
   };
+}
+
+// Request parameters for regal/runTests
+export interface RunTestsParams {
+  uri: string;
+  package: string;
+  name: string;
+}
+
+// Response from regal/runTests
+export interface TestResult {
+  location: { file: string; row: number; col: number };
+  package: string;
+  name: string;
+  fail?: boolean;
+  error?: any;
+  duration: number;
+  output?: string;
 }
 
 export function toggleRegalDiagnostics(): boolean {
@@ -250,7 +269,7 @@ export async function activateRegal(
   const capabilities = extractServerCustomCapabilities(client);
 
   opaOutputChannel.appendLine(
-    `Regal capabilities: explorer=${capabilities.explorerProvider}, inlineEval=${capabilities.inlineEvalProvider}, debug=${capabilities.debugProvider}, serverTesting=${capabilities.serverTestingProvider}`,
+    `Regal capabilities: explorer=${capabilities.explorerProvider}, inlineEval=${capabilities.inlineEvalProvider}, debug=${capabilities.debugProvider}, opaTest=${capabilities.opaTestProvider}`,
   );
 
   if (
@@ -277,11 +296,11 @@ export async function activateRegal(
     );
   }
 
-  if (capabilities.serverTestingProvider && options.featureFlags.enableServerTesting) {
-    client.onNotification(
-      "regal/testLocations",
-      handleRegalTestLocations,
-    );
+  if (
+    capabilities.opaTestProvider
+    && options.featureFlags.enableServerTesting
+  ) {
+    client.onNotification("regal/testLocations", handleRegalTestLocations);
   }
 
   vscode.debug.onDidTerminateDebugSession(session => {
@@ -293,7 +312,8 @@ export async function activateRegal(
     explorerProvider: capabilities.explorerProvider && options.featureFlags.enableExplorer,
     inlineEvalProvider: capabilities.inlineEvalProvider && options.featureFlags.enableInlineEval,
     debugProvider: capabilities.debugProvider && options.featureFlags.enableDebug,
-    serverTestingProvider: capabilities.serverTestingProvider && options.featureFlags.enableServerTesting,
+    opaTestProvider: capabilities.opaTestProvider
+      && options.featureFlags.enableServerTesting,
   };
 
   return { client, capabilities: effectiveCapabilities };
@@ -303,7 +323,9 @@ export function setTreeDataProvider(provider: OPATreeDataProvider): void {
   treeDataProvider = provider;
 }
 
-export function setTestController(controller: { handleTestLocations: (uri: string, locations: TestLocation[]) => void }): void {
+export function setTestController(controller: {
+  handleTestLocations: (uri: string, locations: TestLocation[]) => void;
+}): void {
   testController = controller;
 }
 
@@ -335,6 +357,23 @@ export function deactivateRegal(): Thenable<void> | undefined {
 
 export function isRegalRunning(): boolean {
   return client && client.state === State.Running;
+}
+
+export async function runTests(params: RunTestsParams): Promise<TestResult[]> {
+  if (!client || client.state !== State.Running) {
+    throw new Error("Regal language server is not running");
+  }
+
+  try {
+    const results = await client.sendRequest<TestResult[]>(
+      "regal/runTests",
+      params,
+    );
+    return results;
+  } catch (error) {
+    opaOutputChannel.appendLine(`Error running tests: ${error}`);
+    throw error;
+  }
 }
 
 export async function restartRegal(

--- a/src/test/controller.ts
+++ b/src/test/controller.ts
@@ -1,21 +1,34 @@
 "use strict";
 
 import * as vscode from "vscode";
-import type { TestLocation } from "../ls/clients/regal";
+import type { RunTestsParams, TestLocation } from "../ls/clients/regal";
+import { runTests } from "../ls/clients/regal";
 
 let controller: vscode.TestController;
 
-export function activateTestController(context: vscode.ExtensionContext): vscode.TestController {
+// Store test metadata for each test item
+const testMetadata = new Map<string, { package: string; name: string }>();
+
+export function activateTestController(
+  context: vscode.ExtensionContext,
+): vscode.TestController {
   controller = vscode.tests.createTestController("opaTests", "OPA Tests");
   context.subscriptions.push(controller);
 
-  // TODO: add run profile when test running is implemented
-  // controller.createRunProfile("Run", vscode.TestRunProfileKind.Run, runHandler, true);
+  controller.createRunProfile(
+    "Run",
+    vscode.TestRunProfileKind.Run,
+    runHandler,
+    true,
+  );
 
   return controller;
 }
 
-export function handleTestLocations(fileUri: string, locations: TestLocation[]): void {
+export function handleTestLocations(
+  fileUri: string,
+  locations: TestLocation[],
+): void {
   if (!controller) {
     return;
   }
@@ -25,24 +38,17 @@ export function handleTestLocations(fileUri: string, locations: TestLocation[]):
 
   controller.items.delete(fileUri);
 
-  // Filter for single_test kind only
-  const singleTests = locations.filter(loc => loc.kind === "single_test");
-
-  if (singleTests.length === 0) {
+  if (locations.length === 0) {
     return;
   }
 
   const fileItem = controller.createTestItem(fileUri, fileName, uri);
   controller.items.add(fileItem);
 
-  for (const test of singleTests) {
+  for (const test of locations) {
     // Include line number in ID to handle incremental rules with same name
-    const testId = `${fileUri}:${test.test}:${test.location.row}`;
-    const testItem = controller.createTestItem(
-      testId,
-      test.test,
-      uri,
-    );
+    const testId = `${fileUri}:${test.name}:${test.location.row}`;
+    const testItem = controller.createTestItem(testId, test.name, uri);
     testItem.range = new vscode.Range(
       test.location.row - 1,
       test.location.col - 1,
@@ -50,5 +56,120 @@ export function handleTestLocations(fileUri: string, locations: TestLocation[]):
       test.location.end.col - 1,
     );
     fileItem.children.add(testItem);
+
+    testMetadata.set(testId, {
+      package: test.package,
+      name: test.name,
+    });
+  }
+}
+
+async function runHandler(
+  request: vscode.TestRunRequest,
+  cancellation: vscode.CancellationToken,
+): Promise<void> {
+  const run = controller.createTestRun(request);
+  const queue: vscode.TestItem[] = [];
+
+  if (request.include) {
+    request.include.forEach(test => queue.push(test));
+  } else {
+    controller.items.forEach(test => queue.push(test));
+  }
+
+  for (const test of queue) {
+    if (cancellation.isCancellationRequested) {
+      break;
+    }
+
+    if (test.children.size > 0) {
+      test.children.forEach(child => {
+        if (!request.exclude?.includes(child)) {
+          queue.push(child);
+        }
+      });
+      continue;
+    }
+
+    try {
+      await runSingleTest(test, run);
+    } catch (error) {
+      run.errored(
+        test,
+        new vscode.TestMessage(`Test execution error: ${error}`),
+      );
+    }
+  }
+
+  run.end();
+}
+
+async function runSingleTest(
+  test: vscode.TestItem,
+  run: vscode.TestRun,
+): Promise<void> {
+  run.started(test);
+
+  const metadata = testMetadata.get(test.id);
+  if (!metadata) {
+    run.errored(test, new vscode.TestMessage("Test metadata not found"));
+    return;
+  }
+
+  if (!test.uri) {
+    run.errored(test, new vscode.TestMessage("Test URI not found"));
+    return;
+  }
+
+  const params: RunTestsParams = {
+    uri: test.uri.toString(),
+    package: metadata.package,
+    name: metadata.name,
+  };
+
+  let results;
+  try {
+    results = await runTests(params);
+  } catch (error) {
+    run.errored(test, new vscode.TestMessage(`LSP request failed: ${error}`));
+    return;
+  }
+
+  const result = results[0];
+  if (!result) {
+    run.errored(test, new vscode.TestMessage("No test results returned"));
+    return;
+  }
+
+  const durationMs = result.duration / 1_000_000;
+
+  // Note: The 'fail' property is only set when a test fails
+  if (result.fail !== undefined) {
+    const message = new vscode.TestMessage(
+      result.error ? JSON.stringify(result.error, null, 2) : "Test failed",
+    );
+    if (result.location && test.uri) {
+      message.location = new vscode.Location(
+        test.uri,
+        new vscode.Position(result.location.row - 1, result.location.col - 1),
+      );
+    }
+
+    run.failed(test, message, durationMs);
+  } else {
+    run.passed(test, durationMs);
+  }
+
+  if (result.output) {
+    try {
+      const decodedOutput = Buffer.from(result.output, "base64").toString(
+        "utf-8",
+      );
+      // needed windows line endings to get this looking right
+      const normalizedOutput = decodedOutput.replace(/\n/g, "\r\n");
+      run.appendOutput(normalizedOutput);
+    } catch (error) {
+      run.appendOutput(result.output);
+    }
   }
 }


### PR DESCRIPTION
This allows us to further reduce the need for the OPA binary in the extension.


https://github.com/user-attachments/assets/3ea88c06-61c2-4023-9bd8-b30ee16370c7

In future:

* show print info inline
* use var-values info to show more info inline.