### PR TITLE
build: Inherit path from parent editor for launch

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -18,7 +18,9 @@
         "script": "watch"
       },
       "env": {
-        "VSCODE_DEBUG_MODE": "true"
+        "VSCODE_DEBUG_MODE": "true",
+        // PATH is set explicitly to inherit from the parent process environment
+        "PATH": "${env:PATH}"
       }
     },
     {


### PR DESCRIPTION
This allows you to run vscode from the shell with a specifically crafted PATH containing the binaries you want the extensions to use and then launch the dev mode of the extension with the same PATH