### PR TITLE
server/testing: Support for nested test list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,17 +8,17 @@ Contains a fix for a packing bug in 0.22.0 which caused the test/controller.ts f
 
 ## 0.22.0
 
-* OPA Explorer interface added to view compilation steps [#403](https://github.com/open-policy-agent/vscode-opa/pull/403)
-* Test controller support added to allow 'click to run' testing [#408](https://github.com/open-policy-agent/vscode-opa/pull/408)
-* Updates to highlighting regions
-  * Root document [#397](https://github.com/open-policy-agent/vscode-opa/pull/397)
-  * Metadata comments [#399](https://github.com/open-policy-agent/vscode-opa/pull/399)
-  * No longer hightlight hex colors in Rego code [#395](https://github.com/open-policy-agent/vscode-opa/pull/395)
-* Linter toggle to allow temporary disable of diagnostics [#396](https://github.com/open-policy-agent/vscode-opa/pull/396)
-* Evaluation output improvemnts [#392](https://github.com/open-policy-agent/vscode-opa/pull/392), [#391](https://github.com/open-policy-agent/vscode-opa/pull/391)
-* Binary installation improvements
-  * Install static binaries by default [#394](https://github.com/open-policy-agent/vscode-opa/pull/394)
-  * Add timeouts for binary downloads to make installation experience more understandable during outages [#398](https://github.com/open-policy-agent/vscode-opa/pull/398)
+- OPA Explorer interface added to view compilation steps [#403](https://github.com/open-policy-agent/vscode-opa/pull/403)
+- Test controller support added to allow 'click to run' testing [#408](https://github.com/open-policy-agent/vscode-opa/pull/408)
+- Updates to highlighting regions
+  - Root document [#397](https://github.com/open-policy-agent/vscode-opa/pull/397)
+  - Metadata comments [#399](https://github.com/open-policy-agent/vscode-opa/pull/399)
+  - No longer highlight hex colors in Rego code [#395](https://github.com/open-policy-agent/vscode-opa/pull/395)
+- Linter toggle to allow temporary disable of diagnostics [#396](https://github.com/open-policy-agent/vscode-opa/pull/396)
+- Evaluation output improvements [#392](https://github.com/open-policy-agent/vscode-opa/pull/392), [#391](https://github.com/open-policy-agent/vscode-opa/pull/391)
+- Binary installation improvements
+  - Install static binaries by default [#394](https://github.com/open-policy-agent/vscode-opa/pull/394)
+  - Add timeouts for binary downloads to make installation experience more understandable during outages [#398](https://github.com/open-policy-agent/vscode-opa/pull/398)
 
 
 ## 0.21.0

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -8,6 +8,7 @@ export default tseslint.config(
     ignores: [
       "node_modules/",
       "out/",
+      ".vscode-test/",
     ],
   },
   {

--- a/src/ls/clients/regal.ts
+++ b/src/ls/clients/regal.ts
@@ -72,7 +72,9 @@ let testController:
 // Test location from Regal's regal/testLocations notification
 export interface TestLocation {
   package: string;
+  package_path: string[];
   name: string;
+  root: string;
   location: {
     col: number;
     row: number;
@@ -312,8 +314,7 @@ export async function activateRegal(
     explorerProvider: capabilities.explorerProvider && options.featureFlags.enableExplorer,
     inlineEvalProvider: capabilities.inlineEvalProvider && options.featureFlags.enableInlineEval,
     debugProvider: capabilities.debugProvider && options.featureFlags.enableDebug,
-    opaTestProvider: capabilities.opaTestProvider
-      && options.featureFlags.enableServerTesting,
+    opaTestProvider: capabilities.opaTestProvider && options.featureFlags.enableServerTesting,
   };
 
   return { client, capabilities: effectiveCapabilities };

--- a/src/testing/controller.ts
+++ b/src/testing/controller.ts
@@ -3,17 +3,19 @@
 import * as vscode from "vscode";
 import type { RunTestsParams, TestLocation } from "../ls/clients/regal";
 import { runTests } from "../ls/clients/regal";
+import { TestHierarchyManager } from "./hierarchy-manager";
+import { parseTestId } from "./id";
 
 let controller: vscode.TestController;
-
-// Store test metadata for each test item
-const testMetadata = new Map<string, { package: string; name: string }>();
+let hierarchyManager: TestHierarchyManager;
 
 export function activateTestController(
   context: vscode.ExtensionContext,
 ): vscode.TestController {
   controller = vscode.tests.createTestController("opaTests", "Rego");
   context.subscriptions.push(controller);
+
+  hierarchyManager = new TestHierarchyManager(controller);
 
   controller.createRunProfile(
     "Run",
@@ -34,34 +36,19 @@ export function handleTestLocations(
   }
 
   const uri = vscode.Uri.parse(fileUri);
-  const fileName = fileUri.split("/").pop() || fileUri;
+  const workspaceFolder = vscode.workspace.getWorkspaceFolder(uri);
+  if (!workspaceFolder) {
+    console.warn(`No workspace folder found for file: ${fileUri}`);
+    return;
+  }
 
-  controller.items.delete(fileUri);
+  hierarchyManager.clearTestsForFile(fileUri);
 
   if (locations.length === 0) {
     return;
   }
 
-  const fileItem = controller.createTestItem(fileUri, fileName, uri);
-  controller.items.add(fileItem);
-
-  for (const test of locations) {
-    // Include line number in ID to handle incremental rules with same name
-    const testId = `${fileUri}:${test.name}:${test.location.row}`;
-    const testItem = controller.createTestItem(testId, test.name, uri);
-    testItem.range = new vscode.Range(
-      test.location.row - 1,
-      test.location.col - 1,
-      test.location.end.row - 1,
-      test.location.end.col - 1,
-    );
-    fileItem.children.add(testItem);
-
-    testMetadata.set(testId, {
-      package: test.package,
-      name: test.name,
-    });
-  }
+  hierarchyManager.addTestsForFile(workspaceFolder.uri, fileUri, locations);
 }
 
 async function runHandler(
@@ -110,21 +97,16 @@ async function runSingleTest(
 ): Promise<void> {
   run.started(test);
 
-  const metadata = testMetadata.get(test.id);
-  if (!metadata) {
-    run.errored(test, new vscode.TestMessage("Test metadata not found"));
-    return;
-  }
-
-  if (!test.uri) {
-    run.errored(test, new vscode.TestMessage("Test URI not found"));
+  const parsed = parseTestId(test.id);
+  if (!parsed || !test.uri) {
+    run.errored(test, new vscode.TestMessage("Invalid test"));
     return;
   }
 
   const params: RunTestsParams = {
     uri: test.uri.toString(),
-    package: metadata.package,
-    name: metadata.name,
+    package: parsed.package,
+    name: parsed.name,
   };
 
   let results;
@@ -143,7 +125,6 @@ async function runSingleTest(
 
   const durationMs = result.duration / 1_000_000;
 
-  // Note: The 'fail' property is only set when a test fails
   if (result.fail !== undefined) {
     const message = new vscode.TestMessage(
       result.error ? JSON.stringify(result.error, null, 2) : "Test failed",
@@ -165,7 +146,6 @@ async function runSingleTest(
       const decodedOutput = Buffer.from(result.output, "base64").toString(
         "utf-8",
       );
-      // needed windows line endings to get this looking right
       const normalizedOutput = decodedOutput.replace(/\n/g, "\r\n");
       run.appendOutput(normalizedOutput);
     } catch (error) {

--- a/src/testing/hierarchy-manager.ts
+++ b/src/testing/hierarchy-manager.ts
@@ -1,0 +1,148 @@
+"use strict";
+
+import * as vscode from "vscode";
+import type { TestLocation } from "../ls/clients/regal";
+import { packageId, rootId, testId } from "./id";
+
+// TestHierarchyManager tracks the state of tests that are defined and updates
+// the controller state as test locations change.
+export class TestHierarchyManager {
+  private controller: vscode.TestController;
+  private fileToTestIds = new Map<string, Set<string>>();
+
+  constructor(controller: vscode.TestController) {
+    this.controller = controller;
+  }
+
+  addTestsForFile(workspaceUri: vscode.Uri, fileUri: string, tests: TestLocation[]): void {
+    for (const test of tests) {
+      const rootItem = this.ensureRoot(workspaceUri);
+
+      let parent = rootItem;
+      const currentPath: string[] = [];
+      for (const part of test.package_path) {
+        currentPath.push(part);
+        const fullPackage = `data.${currentPath.join(".")}`;
+        const pkgId = packageId(workspaceUri, fullPackage);
+        parent = this.ensurePackage(parent, pkgId, part);
+      }
+
+      this.addTest(parent, test, fileUri);
+    }
+  }
+
+  clearTestsForFile(fileUri: string): void {
+    const testIds = this.fileToTestIds.get(fileUri);
+    if (!testIds) {
+      return;
+    }
+
+    for (const id of testIds) {
+      const parent = this.findParentOf(id);
+      if (parent) {
+        parent.children.delete(id);
+      }
+    }
+
+    this.fileToTestIds.delete(fileUri);
+    this.cleanupEmptyNodes();
+  }
+
+  private ensureRoot(workspaceUri: vscode.Uri): vscode.TestItem {
+    const id = rootId(workspaceUri);
+    let rootItem = this.controller.items.get(id);
+    if (!rootItem) {
+      const label = vscode.workspace.asRelativePath(workspaceUri, false);
+      rootItem = this.controller.createTestItem(id, label);
+      this.controller.items.add(rootItem);
+    }
+    return rootItem;
+  }
+
+  private ensurePackage(parent: vscode.TestItem, pkgId: string, label: string): vscode.TestItem {
+    let packageItem = parent.children.get(pkgId);
+    if (!packageItem) {
+      packageItem = this.controller.createTestItem(pkgId, label);
+      parent.children.add(packageItem);
+    }
+    return packageItem;
+  }
+
+  private addTest(parent: vscode.TestItem, test: TestLocation, fileUri: string): vscode.TestItem {
+    const uri = vscode.Uri.parse(fileUri);
+    const id = testId(uri, test.package, test.name);
+
+    let testIds = this.fileToTestIds.get(fileUri);
+    if (!testIds) {
+      testIds = new Set();
+      this.fileToTestIds.set(fileUri, testIds);
+    }
+    testIds.add(id);
+
+    const testItem = this.controller.createTestItem(id, test.name, uri);
+    testItem.range = new vscode.Range(
+      test.location.row - 1,
+      test.location.col - 1,
+      test.location.end.row - 1,
+      test.location.end.col - 1,
+    );
+    parent.children.add(testItem);
+
+    return testItem;
+  }
+
+  private cleanupEmptyNodes(): void {
+    for (const [, rootItem] of this.controller.items) {
+      this.cleanupEmptyChildren(rootItem);
+    }
+
+    const emptyRoots: string[] = [];
+    for (const [id, rootItem] of this.controller.items) {
+      if (rootItem.children.size === 0) {
+        emptyRoots.push(id);
+      }
+    }
+    for (const id of emptyRoots) {
+      this.controller.items.delete(id);
+    }
+  }
+
+  private cleanupEmptyChildren(node: vscode.TestItem): void {
+    for (const [, child] of node.children) {
+      this.cleanupEmptyChildren(child);
+    }
+
+    const emptyChildren: string[] = [];
+    for (const [childId, child] of node.children) {
+      if (!child.uri && child.children.size === 0) {
+        emptyChildren.push(childId);
+      }
+    }
+    for (const childId of emptyChildren) {
+      node.children.delete(childId);
+    }
+  }
+
+  private findParentOf(targetId: string): vscode.TestItem | undefined {
+    for (const [, rootItem] of this.controller.items) {
+      const parent = this.findParentOfChild(rootItem, targetId);
+      if (parent) {
+        return parent;
+      }
+    }
+    return undefined;
+  }
+
+  private findParentOfChild(node: vscode.TestItem, targetId: string): vscode.TestItem | undefined {
+    if (node.children.get(targetId)) {
+      return node;
+    }
+    for (const [, child] of node.children) {
+      const found = this.findParentOfChild(child, targetId);
+      if (found) {
+        return found;
+      }
+    }
+    return undefined;
+  }
+}

--- a/src/testing/id.ts
+++ b/src/testing/id.ts
@@ -1,0 +1,29 @@
+"use strict";
+
+import * as vscode from "vscode";
+
+export function rootId(workspaceUri: vscode.Uri): string {
+  return workspaceUri.with({ query: "root" }).toString();
+}
+
+export function packageId(workspaceUri: vscode.Uri, fullPackage: string): string {
+  return workspaceUri.with({ query: "package", fragment: fullPackage }).toString();
+}
+
+export function testId(fileUri: vscode.Uri, pkg: string, name: string): string {
+  return fileUri.with({ query: "test", fragment: `${pkg}:${name}` }).toString();
+}
+
+export function parseTestId(testIdStr: string): { package: string; name: string } | undefined {
+  const uri = vscode.Uri.parse(testIdStr);
+  if (uri.query !== "test") {
+    return undefined;
+  }
+
+  const [pkg, name] = uri.fragment.split(":");
+  if (!pkg || !name) {
+    return undefined;
+  }
+
+  return { package: pkg, name };
+}


### PR DESCRIPTION
Extends the test controller to manage the state of tests in a tree based on root, package and file.

<img width="1727" height="1086" alt="Screenshot 2026-03-10 at 10 15 46" src="https://github.com/user-attachments/assets/da52711b-f214-4ab6-a3a1-9096767cd007" />
