### PR TITLE
Update publish notes for automated releases

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -8,8 +8,12 @@ Creating a new release involves the following steps:
   - Update [CHANGELOG.md](./CHANGELOG.md) with all notable changes since the last tag
   - Update `package.json` with the new version number (e.g. `0.50.0`)
   - Submit a PR to `main` and get it approved and merged
+  - Run `vsce package` to create the VSIX package and ensure it builds correctly first.
 - Create a new tag for the release with that version number (e.g. `git tag v0.50.0`)
-- Run `vsce package` to create the VSIX package and ensure it builds correctly
 - Push the tag (`git push origin v0.50.0`)
-- `vsce publish --pat $TOKEN --no-git-tag-version --no-update-package-json`
+- [Monitor the release](https://github.com/open-policy-agent/vscode-opa/actions), it should be automated in actions on the repo.
 - Check `https://marketplace.visualstudio.com/manage/publishers/tsandall` to ensure it's now in status "Verifying"
+- Create a release in the UI, use the same notes as the changelog update. Also use the
+  generated release notes to get the full commit list at the bottom.
+- Upload the VSIX file manually to the release.
+


### PR DESCRIPTION
Document the new automated publish workflow via GitHub Actions. Add steps for creating GitHub releases with VSIX uploads.