### PR TITLE
Activate extension when workspace contains Rego

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,9 @@
     "regal"
   ],
   "main": "./out/extension",
-  "activationEvents": [],
+  "activationEvents": [
+    "workspaceContains:**/*.rego"
+  ],
   "contributes": {
     "viewsContainers": {
       "activitybar": [


### PR DESCRIPTION
Load the extension only when .rego files are present in the workspace.