### PR TITLE
Ignore .git directory when loading workspace as a bundle

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ or search for "Open Policy Agent" in the 'Extensions' panel.
 | `opa.strictMode` | `false` | Enable [strict-mode](https://www.openpolicyagent.org/docs/latest/policy-language/#strict-mode) for the `OPA: Check File Syntax command`. |
 | `opa.roots` | `[${workspaceFolder}]` | List of paths to load as bundles for policy and data. Defaults to a single entry which is the current workspace root. The variable `${workspaceFolder}` will be resolved as the current workspace root. The variable `${fileDirname}` will be resolved as the directory of the file currently opened in the active window. |
 | `opa.bundleMode`  | `true`  | Enable treating the workspace as a bundle to avoid loading erroneous data JSON/YAML files. It is _NOT_ recommended to disable this. |
+| `opa.bundleIgnorePaths` | `[]` | Additional ignore patterns passed to OPA when bundle mode is enabled. The `.git` directory is always ignored by default. |
 | `opa.schema` | `null` | Path to the [schema](https://www.openpolicyagent.org/docs/latest/policy-language/#using-schemas-to-enhance-the-rego-type-checker) file or directory. If set to `null`, schema evaluation is disabled. As for `opa.roots`, `${workspaceFolder}` and `${fileDirname}` variables can be used in the path. |
 | `opa.languageServers` | `null` | An array of enabled language servers (currently `["regal"]` is supported) |
 | `opa.env` | `{}` | Object of environment variables passed to the process running OPA (e.g. `{"key": "value"}`) |
@@ -140,6 +141,18 @@ Bind the `OPA: Evaluate Package` command to a keyboard shortcut (e.g., ⌘ Shift
 If unable to use `data.json` or `data.yaml` files with `opa.bundleMode` enabled
 you can disable the configuration option and _ALL_ `*.json` and `*.yaml` files
 will be loaded from the workspace.
+
+If you need to exclude additional paths from bundle loading, set
+`opa.bundleIgnorePaths` in your workspace settings. For example:
+
+```json
+{
+    "opa.bundleIgnorePaths": [
+        ".github",
+        "node_modules"
+    ]
+}
+```
 
 
 ### Disabling linting

--- a/package.json
+++ b/package.json
@@ -174,6 +174,16 @@
           "default": true,
           "description": "Enable treating the workspace as a bundle."
         },
+        "opa.bundleIgnorePaths": {
+          "type": [
+            "array"
+          ],
+          "items": {
+            "type": "string"
+          },
+          "default": [],
+          "description": "Additional bundle ignore patterns passed to OPA when bundle mode is enabled. The .git directory is always ignored by default."
+        },
         "opa.schema": {
           "type": [
             "string",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -395,6 +395,7 @@ function activateCheckFile(context: vscode.ExtensionContext) {
         () => {
           if (opa.canUseBundleFlags()) {
             args.push("--bundle");
+            args.push(...opa.getBundleIgnoreParams());
           }
           args.push(...opa.getRoots());
           args.push(...opa.getSchemaParams());
@@ -467,6 +468,7 @@ function activateCoverWorkspace(context: vscode.ExtensionContext) {
         () => {
           if (opa.canUseBundleFlags()) {
             args.push("--bundle");
+            args.push(...opa.getBundleIgnoreParams());
           }
 
           args.push(...opa.getRoots());
@@ -664,6 +666,7 @@ function activateTestWorkspace(context: vscode.ExtensionContext) {
         () => {
           if (opa.canUseBundleFlags()) {
             args.push("--bundle");
+            args.push(...opa.getBundleIgnoreParams());
           }
           args.push(...opa.getRoots());
         },

--- a/src/opa.ts
+++ b/src/opa.ts
@@ -61,12 +61,30 @@ export function getRoots(): string[] {
   return roots.map((root: string) => getDataDir(vscode.Uri.parse(replacePathVariables(root))));
 }
 
+export function getBundleIgnorePaths(): string[] {
+  const ignorePaths = vscode.workspace.getConfiguration("opa").get<string[]>("bundleIgnorePaths", []);
+
+  return [...new Set([".git", ...ignorePaths])];
+}
+
+export function getBundleIgnoreParams(): string[] {
+  if (!canUseBundleFlags()) {
+    return [];
+  }
+
+  return getBundleIgnorePaths().flatMap((ignorePath) => ["--ignore", ignorePath]);
+}
+
 // Returns a list of root data parameters in an array
 // like ["--bundle=file:///a/b/x/", "--bundle=file:///a/b/y"] in bundle mode
 // or ["--data=file:///a/b/x", "--data=file://a/b/y"] otherwise.
 export function getRootParams(): string[] {
   const flag = dataFlag();
   const roots = getRoots();
+
+  if (flag === "--bundle") {
+    return [...getBundleIgnoreParams(), ...roots.map((root) => `${flag}=${root}`)];
+  }
 
   return roots.map((root) => `${flag}=${root}`);
 }


### PR DESCRIPTION
OPA was parsing files inside .git as Rego/data when the workspace was loaded as a bundle, producing errors and slowdowns. Pass --ignore .git on every bundle invocation, and add an opa.bundleIgnorePaths setting so users can exclude additional paths (e.g. .github, node_modules).

A previous attempt (#96) was closed because opa eval --bundle did not honour --ignore at the time; that has since been fixed upstream (open-policy-agent/opa#8062).

Fixes #92