### PR TITLE
Warn Users When a Local Regal Binary for Development Isn't Found

### DIFF
--- a/src/binaries/resolver.ts
+++ b/src/binaries/resolver.ts
@@ -9,6 +9,8 @@ import { BinaryConfig, BinaryInfo } from "./types";
 export function resolveBinary(config: BinaryConfig, fallbackPath?: string): BinaryInfo {
   let path = vscode.workspace.getConfiguration("opa.dependency_paths").get<string>(config.configKey);
 
+  let configuredOriginalPath: string | undefined;
+
   if (path?.trim()) {
     const originalPath = path;
     path = replaceWorkspaceFolderPathVariable(path);
@@ -27,6 +29,8 @@ export function resolveBinary(config: BinaryConfig, fallbackPath?: string): Bina
         ...(versionInfo.error && { error: versionInfo.error }),
       };
     }
+
+    configuredOriginalPath = originalPath;
   }
 
   const systemPath = fallbackPath || config.configKey;
@@ -36,6 +40,10 @@ export function resolveBinary(config: BinaryConfig, fallbackPath?: string): Bina
       path: systemPath,
       source: "system",
       version: versionInfo.version,
+      ...(configuredOriginalPath && {
+        originalPath: configuredOriginalPath,
+        configuredPathMissing: true,
+      }),
       ...(versionInfo.error && { error: versionInfo.error }),
     };
   }
@@ -43,5 +51,9 @@ export function resolveBinary(config: BinaryConfig, fallbackPath?: string): Bina
   return {
     source: "missing",
     version: "missing",
+    ...(configuredOriginalPath && {
+      originalPath: configuredOriginalPath,
+      configuredPathMissing: true,
+    }),
   };
 }

--- a/src/binaries/resolver.ts
+++ b/src/binaries/resolver.ts
@@ -57,3 +57,29 @@ export function resolveBinary(config: BinaryConfig, fallbackPath?: string): Bina
     }),
   };
 }
+
+// warnConfiguredPathMissing logs to the output channel and shows a popup
+// indicating the configured binary path didn't exist on disk. Callers should
+// gate this on binaryInfo.configuredPathMissing being set.
+export function warnConfiguredPathMissing(
+  config: BinaryConfig,
+  binaryInfo: BinaryInfo,
+  outputChannel: vscode.OutputChannel,
+): void {
+  const inspected = vscode.workspace
+    .getConfiguration("opa.dependency_paths")
+    .inspect<string>(config.configKey);
+  const sourceDetail = inspected?.workspaceValue
+    ? "workspace settings (.vscode/settings.json)"
+    : "user settings";
+
+  outputChannel.appendLine(
+    `${config.name}: configured path '${binaryInfo.originalPath}' from ${sourceDetail} not found; falling back to ${
+      binaryInfo.source === "system" ? "system PATH" : "no binary available"
+    }.`,
+  );
+
+  vscode.window.showWarningMessage(
+    `${config.name} binary not found at configured path '${binaryInfo.originalPath}' (from ${sourceDetail}).`,
+  );
+}

--- a/src/binaries/types.ts
+++ b/src/binaries/types.ts
@@ -18,6 +18,7 @@ export interface BinaryInfo {
   path?: string;
   source: "configured" | "system" | "missing";
   originalPath?: string;
+  configuredPathMissing?: boolean;
   version: string;
   error?: string;
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -4,7 +4,14 @@ import * as fs from "fs";
 import * as path from "path";
 import * as vscode from "vscode";
 
-import { BinaryConfig, installBinary, OPA_CONFIG, REGAL_CONFIG, resolveBinary } from "./binaries";
+import {
+  BinaryConfig,
+  installBinary,
+  OPA_CONFIG,
+  REGAL_CONFIG,
+  resolveBinary,
+  warnConfiguredPathMissing,
+} from "./binaries";
 import { activateDebugger } from "./da/activate";
 import {
   activateRegal,
@@ -143,6 +150,12 @@ export async function activate(context: vscode.ExtensionContext) {
 
   // check for missing binaries and prompt to install them
   checkMissingBinaries();
+
+  // warn if the configured opa.dependency_paths.opa points to a non-existent file
+  const opaBinaryInfo = resolveBinary(OPA_CONFIG, "opa");
+  if (opaBinaryInfo.configuredPathMissing) {
+    warnConfiguredPathMissing(OPA_CONFIG, opaBinaryInfo, opaOutputChannel);
+  }
 
   // start Regal language server and wire up the client
   const result = await activateRegal(regalOptions);

--- a/src/ls/clients/regal.ts
+++ b/src/ls/clients/regal.ts
@@ -13,7 +13,7 @@ import {
   ServerOptions,
   State,
 } from "vscode-languageclient/node";
-import { REGAL_CONFIG, resolveBinary } from "../../binaries";
+import { REGAL_CONFIG, resolveBinary, warnConfiguredPathMissing } from "../../binaries";
 import {
   evalResultDecorationType,
   evalResultTargetSuccessDecorationType,
@@ -156,22 +156,7 @@ export async function activateRegal(
   const binaryInfo = resolveBinary(REGAL_CONFIG, "regal");
 
   if (binaryInfo.configuredPathMissing) {
-    const inspected = vscode.workspace
-      .getConfiguration("opa.dependency_paths")
-      .inspect<string>(REGAL_CONFIG.configKey);
-    const sourceDetail = inspected?.workspaceValue
-      ? "workspace settings (.vscode/settings.json)"
-      : "user settings";
-
-    opaOutputChannel.appendLine(
-      `${REGAL_CONFIG.name}: configured path '${binaryInfo.originalPath}' from ${sourceDetail} not found; falling back to ${
-        binaryInfo.source === "system" ? "system PATH" : "no binary available"
-      }.`,
-    );
-
-    vscode.window.showWarningMessage(
-      `Regal binary not found at configured path '${binaryInfo.originalPath}' (from ${sourceDetail}).`,
-    );
+    warnConfiguredPathMissing(REGAL_CONFIG, binaryInfo, opaOutputChannel);
   }
 
   // Validate binary availability

--- a/src/ls/clients/regal.ts
+++ b/src/ls/clients/regal.ts
@@ -155,6 +155,25 @@ export async function activateRegal(
 
   const binaryInfo = resolveBinary(REGAL_CONFIG, "regal");
 
+  if (binaryInfo.configuredPathMissing) {
+    const inspected = vscode.workspace
+      .getConfiguration("opa.dependency_paths")
+      .inspect<string>(REGAL_CONFIG.configKey);
+    const sourceDetail = inspected?.workspaceValue
+      ? "workspace settings (.vscode/settings.json)"
+      : "user settings";
+
+    opaOutputChannel.appendLine(
+      `${REGAL_CONFIG.name}: configured path '${binaryInfo.originalPath}' from ${sourceDetail} not found; falling back to ${
+        binaryInfo.source === "system" ? "system PATH" : "no binary available"
+      }.`,
+    );
+
+    vscode.window.showWarningMessage(
+      `Regal binary not found at configured path '${binaryInfo.originalPath}' (from ${sourceDetail}).`,
+    );
+  }
+
   // Validate binary availability
   if (!binaryInfo.path) {
     clientLock = false;


### PR DESCRIPTION
Recently we ran into an issue where a development regal binary path was checked into source control for Regal, and there was no warning that our configuration had changed! So we were falling through to the regal version on $PATH without knowing why.

These changes add a simple warning if the configured binary path in opa.dependency_paths.regal doesn't exist, whether it be a typo, or an unintended commit (oops!)

Here's a screenshot of the new language server output and warning:


<img width="1119" height="830" alt="Screenshot 2026-05-27 at 3 16 07 PM" src="https://github.com/user-attachments/assets/d1f68d80-d8f2-4017-a19f-30e29271d8ec" />
