### PR TITLE
syntax: highlight the and/or keywords

### DIFF
--- a/syntaxes/Rego.tmLanguage
+++ b/syntaxes/Rego.tmLanguage
@@ -123,7 +123,7 @@
 		<key>keyword</key>
 		<dict>
 			<key>match</key>
-			<string>(^|\s+)(?:(default|not|package|import|as|with|else|some|in|every|if|contains))(?=\s|$)</string>
+			<string>(^|\s+)(?:(default|not|package|import|as|with|else|some|in|every|if|contains|and|or))(?=\s|$)</string>
 			<key>name</key>
 			<string>keyword.other.rego</string>
 		</dict>


### PR DESCRIPTION
Adds highlighting for the new `and` and `or` keywords.

Part of open-policy-agent/opa#8999.