### PR TITLE
build(deps): ignore typescript major bumps in dependabot group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,12 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    ignore:
+      # typescript-eslint v8 peers on typescript ">=4.8.4 <6.1.0", so a
+      # typescript major bump breaks `npm install` for the whole group.
+      # Remove this once typescript-eslint supports typescript 7.
+      - dependency-name: "typescript"
+        update-types: ["version-update:semver-major"]
     groups:
       dependencies:
         patterns:


### PR DESCRIPTION
## Why

[#480](https://github.com/open-policy-agent/vscode-opa/pull/480) fails on both `build` and `lint` at the `npm install --include=dev` step, before anything is compiled or linted:

```
npm error code ERESOLVE
npm error While resolving: typescript-eslint@8.66.0
npm error Found: typescript@7.0.2
npm error Could not resolve dependency:
npm error peer typescript@">=4.8.4 <6.1.0" from typescript-eslint@8.66.0
```

The grouped update bumped `typescript` from `^6.0.3` to `^7.0.2`, which no released `typescript-eslint` supports — 8.67.0 (latest at time of writing) still peers on `typescript >=4.8.4 <6.1.0`. The v8 line only warns when TS 7 is detected (8.65.0); it doesn't support it.

Because the npm group uses `patterns: ["*"]`, a single incompatible major blocks the whole batch of otherwise-safe patch/minor bumps.

## What

Ignore `semver-major` updates for `typescript` so grouped dependency PRs stay mergeable. The comment notes to drop this once typescript-eslint supports TypeScript 7.

Follow-up: #480 still needs `@dependabot recreate` (or a `@dependabot ignore typescript major version` comment) to pick up the new config and drop the TS 7 bump.